### PR TITLE
Add unit tests for post and api_helpers

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from utils import api_helpers
+
+
+def test_to_snake_case():
+    assert api_helpers.to_snake_case('Test Field Name') == 'test_field_name'
+
+
+def test_fetch_custom_fields(monkeypatch):
+    fake_response = {
+        'results': [
+            {'id': 1, 'name': 'Invoice Date', 'data_type': 'date'},
+            {'id': 2, 'name': 'Amount Due', 'data_type': 'monetary'},
+        ]
+    }
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return fake_response
+
+    def fake_get(url, headers=None):
+        return Resp()
+
+    monkeypatch.setattr(api_helpers.requests, 'get', fake_get)
+    result = api_helpers.fetch_custom_fields('http://api', {})
+    assert result == {
+        'invoice_date': {'id': 1, 'data_type': 'date'},
+        'amount_due': {'id': 2, 'data_type': 'monetary'}
+    }

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import os
+import post
+
+
+def test_to_snake_case_basic():
+    assert post.to_snake_case("Hello World") == "hello_world"
+
+
+def test_to_snake_case_special_chars():
+    assert post.to_snake_case(" Example---Test! ") == "example_test"
+
+
+def test_clean_fields_date_and_money():
+    fields = {
+        "date_field": "01.02.2023",
+        "money_field": "1234,50",
+        "ignored_field": "value"
+    }
+    field_meta = {
+        "date_field": {"data_type": "date"},
+        "money_field": {"data_type": "monetary"}
+    }
+    cleaned = post.clean_fields(fields, field_meta)
+    assert cleaned == {
+        "date_field": "2023-02-01",
+        "money_field": "1234.5"
+    }
+
+
+def test_clean_fields_invalid_date():
+    fields = {"date_field": "32/13/2023"}
+    field_meta = {"date_field": {"data_type": "date"}}
+    cleaned = post.clean_fields(fields, field_meta)
+    assert cleaned == {}
+
+
+class DummyChat:
+    def __init__(self, content):
+        self.content = content
+
+
+class DummyMessage:
+    def __init__(self, content):
+        self.message = DummyChat(content)
+
+
+class DummyChoices:
+    def __init__(self, content):
+        self.choices = [DummyMessage(content)]
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    class chat:
+        class completions:
+            @staticmethod
+            def create(*args, **kwargs):
+                return DummyChoices(
+                    "Random text {\"title\": \"Test Document\", \"fields\": {\"amount\": \"12.34\"}} end"
+                )
+
+
+def test_generate_metadata_with_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr(post, "OpenAI", lambda api_key=None: DummyClient())
+    result = post.generate_metadata_with_openai("some ocr text", ["amount"])
+    assert result == {"title": "Test Document", "fields": {"amount": "12.34"}}


### PR DESCRIPTION
## Summary
- add tests for utility functions and API helpers
- mock OpenAI client and requests to test functions without network

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a1dc650c832abaaebd88444e96dc