### PR TITLE
Handle tag dicts in postprocess_all

### DIFF
--- a/src/postprocess_all.py
+++ b/src/postprocess_all.py
@@ -54,11 +54,22 @@ def main():
     # Process each document
     for document in documents:
         document_id = document["id"]
-        document_tags = document.get("tags", [])
+
+        # Process tags to handle both integers and dictionaries
+        document_tag_ids = set()
+        for tag in document.get("tags", []):
+            if isinstance(tag, dict):
+                tag_id = tag.get("id")
+                if tag_id is not None:
+                    document_tag_ids.add(tag_id)
+            elif isinstance(tag, int):
+                document_tag_ids.add(tag)
 
         # Skip documents that already have the 'gpt-correspondant' tag
-        if gpt_tag_id in document_tags:
-            logging.info(f"Skipping document ID {document_id} as it already has the 'gpt-correspondant' tag.")
+        if gpt_tag_id in document_tag_ids:
+            logging.info(
+                f"Skipping document ID {document_id} as it already has the 'gpt-correspondant' tag."
+            )
             continue
 
         # Process the document

--- a/tests/test_postprocess_all.py
+++ b/tests/test_postprocess_all.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import postprocess_all
+
+
+def test_skip_documents_with_tag_dicts(monkeypatch):
+    docs = [
+        {'id': 1, 'tags': [{'id': 5}]},
+        {'id': 2, 'tags': [4, {'id': 5}]},
+        {'id': 3, 'tags': [4]},
+    ]
+
+    monkeypatch.setattr(postprocess_all, 'fetch_all_documents', lambda: docs)
+    monkeypatch.setattr(postprocess_all, 'fetch_tags', lambda: {'gpt-correspondant': {'id': 5}})
+
+    processed = []
+    def fake_process_document(doc_id):
+        processed.append(doc_id)
+    monkeypatch.setattr(postprocess_all, 'process_document', fake_process_document)
+
+    postprocess_all.main()
+
+    assert processed == [3]


### PR DESCRIPTION
## Summary
- ensure `postprocess_all` supports tag lists with dicts like `postprocess`
- add regression test for skipping documents when tags are dicts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848aae4256c832a9c3b07940ab916e0