### PR TITLE
Fix tag typo

### DIFF
--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -275,22 +275,22 @@ def main(doc_id):
             sys.exit(1)
     elif ai_response["status"] == "no_match":
         logging.warning(
-            "AI could not determine a correspondent. Adding 'gpt-correspondant-unable-to-determine' tag."
+            "AI could not determine a correspondent. Adding 'gpt-correspondent-unable-to-determine' tag."
         )
 
         # Fetch existing tags
         tags = fetch_tags()
-        unable_to_determine_tag_name = "gpt-correspondant-unable-to-determine"
+        unable_to_determine_tag_name = "gpt-correspondent-unable-to-determine"
         unable_to_determine_tag = tags.get(unable_to_determine_tag_name.lower())
 
-        # Create the 'gpt-correspondant-unable-to-determine' tag if it does not exist
+        # Create the 'gpt-correspondent-unable-to-determine' tag if it does not exist
         if not unable_to_determine_tag:
             logging.info(
                 f"No matching tag found for '{unable_to_determine_tag_name}'. Creating a new one."
             )
             unable_to_determine_tag = create_tag(unable_to_determine_tag_name)
 
-        # Add the 'gpt-correspondant-unable-to-determine' tag to the document
+        # Add the 'gpt-correspondent-unable-to-determine' tag to the document
         if unable_to_determine_tag["id"] not in current_tags:
             logging.info(
                 f"Adding tag '{unable_to_determine_tag['name']}' (ID: {unable_to_determine_tag['id']}) to document ID {doc_id}."
@@ -323,7 +323,7 @@ def main(doc_id):
         # Fetch tags
         logging.info("Fetching existing tags.")
         tags = fetch_tags()
-        tag_name = "gpt-correspondant"
+        tag_name = "gpt-correspondent"
         tag = tags.get(tag_name.lower())
 
         # Create new tag if not found
@@ -349,22 +349,22 @@ def main(doc_id):
         == "the ocr text does not provide a clear correspondent name."
     ):
         logging.warning(
-            "OpenAI could not determine a correspondent. Adding 'gpt-correspondant-unable-to-determine' tag."
+            "OpenAI could not determine a correspondent. Adding 'gpt-correspondent-unable-to-determine' tag."
         )
 
         # Fetch existing tags
         tags = fetch_tags()
-        unable_to_determine_tag_name = "gpt-correspondant-unable-to-determine"
+        unable_to_determine_tag_name = "gpt-correspondent-unable-to-determine"
         unable_to_determine_tag = tags.get(unable_to_determine_tag_name.lower())
 
-        # Create the 'gpt-correspondant-unable-to-determine' tag if it does not exist
+        # Create the 'gpt-correspondent-unable-to-determine' tag if it does not exist
         if not unable_to_determine_tag:
             logging.info(
                 f"No matching tag found for '{unable_to_determine_tag_name}'. Creating a new one."
             )
             unable_to_determine_tag = create_tag(unable_to_determine_tag_name)
 
-        # Add the 'gpt-correspondant-unable-to-determine' tag to the document
+        # Add the 'gpt-correspondent-unable-to-determine' tag to the document
         if unable_to_determine_tag["id"] not in current_tags:
             logging.info(
                 f"Adding tag '{unable_to_determine_tag['name']}' (ID: {unable_to_determine_tag['id']}) to document ID {doc_id}."

--- a/src/postprocess_all.py
+++ b/src/postprocess_all.py
@@ -44,7 +44,7 @@ def fetch_all_documents():
 
 def main():
     logging.info(
-        "Starting post-processing for all documents without the 'gpt-correspondant' tag."
+        "Starting post-processing for all documents without the 'gpt-correspondent' tag."
     )
 
     # Fetch all documents
@@ -52,11 +52,11 @@ def main():
 
     # Fetch existing tags
     tags = fetch_tags()
-    gpt_tag = tags.get("gpt-correspondant")
+    gpt_tag = tags.get("gpt-correspondent")
 
     if not gpt_tag:
         logging.error(
-            "The 'gpt-correspondant' tag does not exist. Please create it first."
+            "The 'gpt-correspondent' tag does not exist. Please create it first."
         )
         sys.exit(1)
 
@@ -76,10 +76,10 @@ def main():
             elif isinstance(tag, int):
                 document_tag_ids.add(tag)
 
-        # Skip documents that already have the 'gpt-correspondant' tag
+        # Skip documents that already have the 'gpt-correspondent' tag
         if gpt_tag_id in document_tag_ids:
             logging.info(
-                f"Skipping document ID {document_id} as it already has the 'gpt-correspondant' tag."
+                f"Skipping document ID {document_id} as it already has the 'gpt-correspondent' tag."
             )
             continue
 

--- a/tests/test_postprocess_all.py
+++ b/tests/test_postprocess_all.py
@@ -15,7 +15,7 @@ def test_skip_documents_with_tag_dicts(monkeypatch):
 
     monkeypatch.setattr(postprocess_all, "fetch_all_documents", lambda: docs)
     monkeypatch.setattr(
-        postprocess_all, "fetch_tags", lambda: {"gpt-correspondant": {"id": 5}}
+        postprocess_all, "fetch_tags", lambda: {"gpt-correspondent": {"id": 5}}
     )
 
     processed = []


### PR DESCRIPTION
## Summary
- rename all occurrences of the misspelled `gpt-correspondant` tag to `gpt-correspondent`
- adjust test to use the corrected tag

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b565b87c832a9506e1dfd2f3eba7