### PR TITLE
Fix isort config for policy compliance

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black


### PR DESCRIPTION
## Summary
- add `.isort.cfg` so imports follow the Black profile

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac6488fc4832a8a57cdfdc1fe1b87